### PR TITLE
Minor bugfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='Sebastian Otálora',
     author_email='sebastianffx@gmail.com',
     url='https://github.com/sebastianffx/stainlib',
-    packages=find_packages(include=['stainlib']),
+    packages=find_packages(),
     install_requires=[
         'numpy',
         'matplotlib',


### PR DESCRIPTION
Remove include=['stainlib'] from find_packages in setup.py to properly detect all submodules.
I left it there by mistake.